### PR TITLE
[ROCm] Add a HIP device for AMD GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,9 @@ if (hip)
     frame/Frame.hip
     renderer/DirectLight_impl.hip
     renderer/Raycast_impl.hip
+    scene/volume/spatial_field/BlockStructuredField.hip
+    scene/volume/spatial_field/GridAccel.hip
+    scene/volume/spatial_field/UnstructuredField.hip
     scene/VisionarayScene.hip
   )
   target_compile_definitions(${PROJECT_NAME}_hip PRIVATE WITH_HIP=1)
@@ -230,7 +233,11 @@ if (hip)
     target_compile_definitions(${PROJECT_NAME}_hip PRIVATE _USE_MATH_DEFINES)
   endif()
   if (nanovdb)
-    message(WARNING "No VDB support with HIP")
+    target_sources(${PROJECT_NAME}_hip PRIVATE
+        scene/volume/spatial_field/NanoVDBField.hip)
+    target_link_libraries(${PROJECT_NAME}_hip
+      $<BUILD_INTERFACE:vsnray_nanovdb>)
+    target_compile_definitions(${PROJECT_NAME}_hip PRIVATE WITH_NANOVDB=1)
   endif()
 
   target_link_libraries(${PROJECT_NAME}_hip
@@ -272,6 +279,9 @@ endif()
 set(DEVICE_LIBS ${PROJECT_NAME})
 if (cuda)
   set(DEVICE_LIBS ${DEVICE_LIBS} ${PROJECT_NAME}_cuda)
+endif()
+if (hip)
+  set(DEVICE_LIBS ${DEVICE_LIBS} ${PROJECT_NAME}_hip)
 endif()
 
 install(TARGETS ${DEVICE_LIBS}

--- a/DeviceBVH.h
+++ b/DeviceBVH.h
@@ -179,12 +179,14 @@ void DeviceBVH<P>::rebuildHostIndexBVH2() {
     hPrimitives = (P *)m_primitives;
   }
 #elif defined(WITH_HIP)
-  hitPointerAttribute_t attributes = {};
+  hipPointerAttribute_t attributes = {};
   HIP_SAFE_CALL(hipPointerGetAttributes(&attributes,m_primitives));
-  if (attributes.memoryType == hipMemoryTypeDevice) {
+  if (attributes.type == hipMemoryTypeDevice) {
     hPrimitives = (P *)std::malloc(sizeof(P)*m_numPrimitives);
     HIP_SAFE_CALL(hipMemcpy(hPrimitives,m_primitives,sizeof(P)*m_numPrimitives,
                             hipMemcpyDeviceToHost));
+  } else {
+    hPrimitives = (P *)m_primitives;
   }
 #else
   hPrimitives = (P *)m_primitives;
@@ -208,7 +210,7 @@ void DeviceBVH<P>::rebuildHostIndexBVH2() {
     std::free(hPrimitives);
   }
 #elif defined(WITH_HIP)
-  if (attributes.memoryType == hipMemoryTypeDevice) {
+  if (attributes.type == hipMemoryTypeDevice) {
     std::free(hPrimitives);
   }
 #endif
@@ -264,7 +266,7 @@ void DeviceBVH<P>::rebuildDeviceIndexBVH2() {
 #elif defined(WITH_HIP)
     hipPointerAttribute_t attributes = {};
     HIP_SAFE_CALL(hipPointerGetAttributes(&attributes,m_primitives));
-    if (attributes.memoryType == hipMemoryTypeDevice) {
+    if (attributes.type == hipMemoryTypeDevice) {
       dPrimitives = (P *)m_primitives;
     } else {
       HIP_SAFE_CALL(hipMalloc(&dPrimitives,sizeof(P)*m_numPrimitives));
@@ -283,7 +285,7 @@ void DeviceBVH<P>::rebuildDeviceIndexBVH2() {
       CUDA_SAFE_CALL(cudaFree(dPrimitives));
     }
 #elif defined(WITH_HIP)
-    if (attributes.memoryType == hipMemoryTypeHost) {
+    if (attributes.type != hipMemoryTypeDevice) {
       HIP_SAFE_CALL(hipFree(dPrimitives));
     }
 #endif

--- a/DeviceCopyableObjects.h
+++ b/DeviceCopyableObjects.h
@@ -1407,8 +1407,10 @@ struct BLS
 VSNRAY_FUNC
 inline aabb get_bounds(const BLS &bls)
 {
-#ifdef WITH_HIP
-  // with HIP we currenlty assume that TLSs are built on the host:
+#if defined(WITH_HIP) && !defined(__HIP_DEVICE_COMPILE__)
+  // with HIP we currently assume that TLSs are built on the host, so the
+  // device-resident root node is staged back via hipMemcpy on the host pass;
+  // the device pass falls through to the direct node access below.
   bvh_node hip_root;
   if (bls.type == BLS::Triangle && bls.asTriangle.num_nodes())
     HIP_SAFE_CALL(hipMemcpy(

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ follow. You need to install
 Visionaray installs as header-only if you deactivate all the features as in the
 CI script (you don't even need CUDA).
 
-`anari-visionaray` compiles into separate devices for CPU, CUDA, and an
-experimental but seldom tested HIP version. The latter two must be enabled with
-CMake for them to compile.
+`anari-visionaray` compiles into separate devices for CPU, CUDA, and HIP (for
+AMD GPUs via ROCm). The HIP device implements the same surface and volume
+spatial-field paths as the CUDA device (structured, unstructured, AMR, and
+NanoVDB fields). The CUDA and HIP devices must be enabled with CMake for them
+to compile.
 
 List of Proprietary ANARI Extensions
 ------------------------------------

--- a/frame/Frame.cpp
+++ b/frame/Frame.cpp
@@ -487,8 +487,12 @@ void Frame::wait()
 {
 #ifdef WITH_CUDA
   CUDA_SAFE_CALL(cudaEventSynchronize(m_eventStop));
+  if (deviceState()->currentFrame == this)
+    deviceState()->currentFrame = nullptr;
 #elif defined(WITH_HIP)
   HIP_SAFE_CALL(hipEventSynchronize(m_eventStop));
+  if (deviceState()->currentFrame == this)
+    deviceState()->currentFrame = nullptr;
 #else
   if (m_future.valid()) {
     m_future.get();

--- a/frame/Frame.h
+++ b/frame/Frame.h
@@ -82,7 +82,7 @@ struct Frame : public helium::BaseFrame
   template <typename Array>
   void *mapHostDeviceArray(Array &arr, bool onDevice=false)
   {
-#ifdef WITH_CUDA
+#if defined(WITH_CUDA) || defined(WITH_HIP)
     if (!onDevice) {
       arr.unmapDevice();
       return (void *)arr.hostPtr();

--- a/scene/VisionarayScene.cpp
+++ b/scene/VisionarayScene.cpp
@@ -82,15 +82,9 @@ void VisionaraySceneImpl::commit()
   if (type == World) {
     // Build TLS
     if (!m_worldBLSs.empty()) {
-#if defined(WITH_HIP)
-      m_worldTLS.update(m_worldBLSs.devicePtr(),
-                        m_worldBLSs.size(),
-                        0); // no device LBVH builder on hip yet!
-#else
       m_worldTLS.update(m_worldBLSs.devicePtr(),
                         m_worldBLSs.size(),
                         BVH_FLAG_PREFER_FAST_BUILD);
-#endif
     }
 
     // Build flat list of lights

--- a/scene/volume/spatial_field/BlockStructuredField.cpp
+++ b/scene/volume/spatial_field/BlockStructuredField.cpp
@@ -1,4 +1,5 @@
 // Copyright 2023-2026 Stefan Zellmann
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "BlockStructuredField.h"
@@ -108,6 +109,13 @@ void BlockStructuredField::finalize()
   m_samplingBVH = cuda_index_bvh<dco::Block>(hostBVH);
 
   vfield.asBlockStructured.samplingBVH = m_samplingBVH.ref();
+#elif defined(WITH_HIP)
+  auto hostBVH = builder.build(
+    index_bvh<dco::Block>{}, m_blocks.data(), m_blocks.size());
+
+  m_samplingBVH = hip_index_bvh<dco::Block>(hostBVH);
+
+  vfield.asBlockStructured.samplingBVH = m_samplingBVH.ref();
 #else
   auto samplingBVH2 = builder.build(
     index_bvh<dco::Block>{}, m_blocks.data(), m_blocks.size());
@@ -141,7 +149,7 @@ aabb BlockStructuredField::bounds() const
   return m_bounds;
 }
 
-#ifdef WITH_CUDA
+#if defined(WITH_CUDA) || defined(WITH_HIP)
 __global__ void BlockStructuredField_buildGridGPU(dco::GridAccel    vaccel,
                                                   const dco::Block *blocks,
                                                   size_t            numBlocks)
@@ -174,6 +182,24 @@ __global__ void BlockStructuredField_buildGridGPU(dco::GridAccel    vaccel,
 void BlockStructuredField::buildGrid()
 {
 #ifdef WITH_CUDA
+  box3f worldBounds = {bounds().min,bounds().max};
+  worldBounds.min = vfield.pointToVoxelSpace(worldBounds.min);
+  worldBounds.max = vfield.pointToVoxelSpace(worldBounds.max);
+  int3 dims{
+    div_up(int(worldBounds.max.x-worldBounds.min.x),8),
+    div_up(int(worldBounds.max.y-worldBounds.min.y),8),
+    div_up(int(worldBounds.max.z-worldBounds.min.z),8)
+  };
+  box3f gridBounds = worldBounds;
+  m_gridAccel.init(dims, worldBounds, gridBounds);
+
+  dco::GridAccel &vaccel = m_gridAccel.visionarayAccel();
+
+  size_t numThreads = 1024;
+  size_t numBlocks = m_blocks.size();
+  BlockStructuredField_buildGridGPU<<<div_up(numBlocks, numThreads), numThreads>>>(
+    vaccel, m_blocks.devicePtr(), numBlocks);
+#elif defined(WITH_HIP)
   box3f worldBounds = {bounds().min,bounds().max};
   worldBounds.min = vfield.pointToVoxelSpace(worldBounds.min);
   worldBounds.max = vfield.pointToVoxelSpace(worldBounds.max);

--- a/scene/volume/spatial_field/BlockStructuredField.h
+++ b/scene/volume/spatial_field/BlockStructuredField.h
@@ -29,6 +29,8 @@ struct BlockStructuredField : public SpatialField
   // sampling accel
 #ifdef WITH_CUDA
   cuda_index_bvh<dco::Block> m_samplingBVH;
+#elif defined(WITH_HIP)
+  hip_index_bvh<dco::Block> m_samplingBVH;
 #else
   index_bvh4<dco::Block> m_samplingBVH;
 #endif

--- a/scene/volume/spatial_field/BlockStructuredField.hip
+++ b/scene/volume/spatial_field/BlockStructuredField.hip
@@ -1,0 +1,4 @@
+// Copyright 2023-2026 Stefan Zellmann
+// SPDX-License-Identifier: Apache-2.0
+
+#include "BlockStructuredField.cpp"

--- a/scene/volume/spatial_field/Connectivity.h
+++ b/scene/volume/spatial_field/Connectivity.h
@@ -84,7 +84,7 @@ struct Face
 {
   Face() = default;
 
-  __host__ __device__
+  VSNRAY_FUNC
   Face(const float4 *vertices, uint64_t i0, uint64_t i1, uint64_t i2)
     : vertices(vertices)
   {
@@ -94,7 +94,7 @@ struct Face
     indices[3] = ~0ull;
   }
 
-  __host__ __device__
+  VSNRAY_FUNC
   Face(const float4 *vertices, uint64_t i0, uint64_t i1, uint64_t i2, uint64_t i3)
     : vertices(vertices)
   {
@@ -104,20 +104,20 @@ struct Face
     indices[3] = i3;
   }
 
-  __host__ __device__
+  VSNRAY_FUNC
   inline int numTriangles() const
   {
     if (indices[3] == ~0ull) return 1;
     else return 2;
   }
 
-  __host__ __device__
+  VSNRAY_FUNC
   inline float4 vertex(int i) const
   {
     return vertices[indices[i]];
   }
 
-  __host__ __device__
+  VSNRAY_FUNC
   inline basic_triangle<3,float> triangle(int i) const
   {
     float3 v1, v2, v3;
@@ -137,7 +137,7 @@ struct Face
     return tri;
   }
 
-  __host__
+  VSNRAY_CPU_FUNC
   inline bool isPlanar() const
   {
     if (numTriangles() == 1)
@@ -158,7 +158,7 @@ struct Face
 
 struct UElem
 {
-  __host__ __device__
+  VSNRAY_FUNC
   UElem(const dco::UElem &elem)
   {
     numVertices = elem.end-elem.begin;
@@ -173,7 +173,7 @@ struct UElem
     }
   }
 
-  __host__ __device__
+  VSNRAY_FUNC
   int numFaces() const
   {
     if (numVertices == 4) return 4;
@@ -184,7 +184,7 @@ struct UElem
     return -1;
   }
 
-  __host__ __device__
+  VSNRAY_FUNC
   inline Face face(int i) const
   {
     if (numVertices == 4) {
@@ -200,7 +200,7 @@ struct UElem
     return {};
   }
 
-  __host__
+  VSNRAY_CPU_FUNC
   inline UniqueFace uniqueFace(int i) const
   {
     uint64_t I[4];
@@ -257,7 +257,7 @@ struct UElem
     return f;
   }
 
-  __host__
+  VSNRAY_CPU_FUNC
   inline bool allFacesPlanar() const
   {
     for (int i=0; i<numFaces(); ++i) {
@@ -266,7 +266,7 @@ struct UElem
     return true;
   }
 
-  __host__
+  VSNRAY_CPU_FUNC
   inline bool hasCoplanarFaces() const
   {
     for (int i=0; i<numFaces(); ++i) {
@@ -290,7 +290,7 @@ struct UElem
   }
 
   // test if *either* of the faces' winding order is wrong
-  __host__
+  VSNRAY_CPU_FUNC
   inline bool checkWindingOrder() const
   {
     for (int i=0; i<numFaces(); ++i) {
@@ -315,7 +315,7 @@ struct UElem
   }
 
   // test if *all* of the faces' winding order is wrong
-  __host__
+  VSNRAY_CPU_FUNC
   inline bool checkWindingOrderFlipped() const
   {
     for (int i=0; i<numFaces(); ++i) {
@@ -339,7 +339,7 @@ struct UElem
     return true;
   }
 
-  __host__
+  VSNRAY_CPU_FUNC
   inline bool isValid() const
   {
     // TODO: test and enable winding order check:

--- a/scene/volume/spatial_field/GridAccel.cpp
+++ b/scene/volume/spatial_field/GridAccel.cpp
@@ -73,6 +73,8 @@ void GridAccel::computeMaxOpacities(dco::TransferFunction1D tf)
   DevicePointer<dco::GridAccel> gridPtr(&vaccel);
 #ifdef WITH_CUDA
   cuda::for_each(stream, 0, numMCs,
+#elif defined(WITH_HIP)
+  hip::for_each(stream, 0, numMCs,
 #else
   parallel::for_each(deviceState()->threadPool, 0, numMCs,
 #endif

--- a/scene/volume/spatial_field/GridAccel.hip
+++ b/scene/volume/spatial_field/GridAccel.hip
@@ -1,0 +1,4 @@
+// Copyright 2023-2026 Stefan Zellmann
+// SPDX-License-Identifier: Apache-2.0
+
+#include "GridAccel.cpp"

--- a/scene/volume/spatial_field/NanoVDBField.cpp
+++ b/scene/volume/spatial_field/NanoVDBField.cpp
@@ -1,8 +1,11 @@
 // Copyright 2023-2026 Stefan Zellmann
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #ifdef WITH_CUDA
 #include <cuda_runtime.h>
+#elif defined(WITH_HIP)
+#include <hip/hip_runtime.h>
 #endif
 // nanovdb
 #include <nanovdb/io/IO.h>
@@ -73,7 +76,7 @@ aabb NanoVDBField::bounds() const
   return m_bounds;
 }
 
-#ifdef WITH_CUDA
+#if defined(WITH_CUDA) || defined(WITH_HIP)
 __global__ void NanoVDBField_buildGridGPU(dco::GridAccel vaccel,
                                          nanovdb::NanoGrid<float> *grid)
 {
@@ -111,7 +114,7 @@ __global__ void NanoVDBField_buildGridGPU(dco::GridAccel vaccel,
 
 void NanoVDBField::buildGrid()
 {
-#if defined(WITH_CUDA)
+#if defined(WITH_CUDA) || defined(WITH_HIP)
   int3 gridDims{16, 16, 16};
   box3f worldBounds = {bounds().min,bounds().max};
   box3f gridBounds = worldBounds;
@@ -126,8 +129,6 @@ void NanoVDBField::buildGrid()
 
   NanoVDBField_buildGridGPU<<<numBlocks, numThreads>>>(
     vaccel, vfield.asNanoVDB.grid);
-#elif defined(WITH_HIP)
-  return;
 #else
   int3 gridDims{16, 16, 16};
   box3f worldBounds = {bounds().min,bounds().max};

--- a/scene/volume/spatial_field/NanoVDBField.hip
+++ b/scene/volume/spatial_field/NanoVDBField.hip
@@ -1,0 +1,4 @@
+// Copyright 2023-2026 Stefan Zellmann
+// SPDX-License-Identifier: Apache-2.0
+
+#include "NanoVDBField.cpp"

--- a/scene/volume/spatial_field/UnstructuredField.cpp
+++ b/scene/volume/spatial_field/UnstructuredField.cpp
@@ -1,4 +1,5 @@
 // Copyright 2023-2026 Stefan Zellmann
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "array/Array3D.h"
@@ -231,6 +232,8 @@ void UnstructuredField::finalize()
 
 #ifdef WITH_CUDA
     m_shellBVH = cuda_index_bvh<basic_triangle<3,float>>(shellBVH2);
+#elif defined(WITH_HIP)
+    m_shellBVH = hip_index_bvh<basic_triangle<3,float>>(shellBVH2);
 #else
     bvh_collapser collapser;
     collapser.collapse(shellBVH2, m_shellBVH, deviceState()->threadPool);
@@ -254,6 +257,18 @@ void UnstructuredField::finalize()
   if (!m_grids.empty()) {
     m_gridBVH = builder.build(
       cuda_index_bvh<dco::UElemGrid>{}, m_grids.devicePtr(), m_grids.size());
+  }
+#elif defined(WITH_HIP)
+  lbvh_builder builder; // the only GPU builder Visionaray has (for now..)
+
+  if (!m_elements.empty()) {
+    m_elementBVH = builder.build(
+      hip_index_bvh<dco::UElem>{}, m_elements.devicePtr(), m_elements.size());
+  }
+
+  if (!m_grids.empty()) {
+    m_gridBVH = builder.build(
+      hip_index_bvh<dco::UElemGrid>{}, m_grids.devicePtr(), m_grids.size());
   }
 #else
   binned_sah_builder builder;
@@ -316,6 +331,24 @@ aabb UnstructuredField::bounds() const
                                 cudaMemcpyDeviceToHost));
       bounds.insert(rootNode.get_bounds());
     }
+#elif defined(WITH_HIP)
+    if (m_elementBVH.num_nodes()) {
+      bvh_node rootNode;
+      HIP_SAFE_CALL(hipMemcpy(&rootNode,
+                              m_elementBVH.nodes().data(),
+                              sizeof(rootNode),
+                              hipMemcpyDeviceToHost));
+      bounds.insert(rootNode.get_bounds());
+    }
+
+    if (m_gridBVH.num_nodes()) {
+      bvh_node rootNode;
+      HIP_SAFE_CALL(hipMemcpy(&rootNode,
+                              m_gridBVH.nodes().data(),
+                              sizeof(rootNode),
+                              hipMemcpyDeviceToHost));
+      bounds.insert(rootNode.get_bounds());
+    }
 #else
     if (m_elementBVH.num_nodes())
       bounds.insert(m_elementBVH.node(0).get_bounds());
@@ -331,7 +364,7 @@ aabb UnstructuredField::bounds() const
   return {};
 }
 
-#ifdef WITH_CUDA
+#if defined(WITH_CUDA) || defined(WITH_HIP)
 __global__ void UnstructuredField_buildGridGPU(dco::GridAccel    vaccel,
                                                const vec4f      *vertices,
                                                const dco::UElem *elements,
@@ -364,6 +397,19 @@ __global__ void UnstructuredField_buildGridGPU(dco::GridAccel    vaccel,
 void UnstructuredField::buildGrid()
 {
 #ifdef WITH_CUDA
+  int3 dims{64, 64, 64};
+  box3f worldBounds = {bounds().min,bounds().max};
+  box3f gridBounds = worldBounds;
+  m_gridAccel.init(dims, worldBounds, gridBounds);
+
+  dco::GridAccel &vaccel = m_gridAccel.visionarayAccel();
+
+  size_t numThreads = 1024;
+  size_t numElems = m_elements.size();
+  UnstructuredField_buildGridGPU<<<div_up(numElems, numThreads), numThreads>>>(
+    vaccel, m_vertices.devicePtr(), m_elements.devicePtr(), numElems, vfield.cellSize);
+  // TODO: stitcher gridlets
+#elif defined(WITH_HIP)
   int3 dims{64, 64, 64};
   box3f worldBounds = {bounds().min,bounds().max};
   box3f gridBounds = worldBounds;

--- a/scene/volume/spatial_field/UnstructuredField.h
+++ b/scene/volume/spatial_field/UnstructuredField.h
@@ -38,6 +38,9 @@ struct UnstructuredField : public SpatialField
 #ifdef WITH_CUDA
   cuda_index_bvh<dco::UElem> m_elementBVH;
   cuda_index_bvh<dco::UElemGrid> m_gridBVH;
+#elif defined(WITH_HIP)
+  hip_index_bvh<dco::UElem> m_elementBVH;
+  hip_index_bvh<dco::UElemGrid> m_gridBVH;
 #else
   bvh4<dco::UElem> m_elementBVH;
   bvh4<dco::UElemGrid> m_gridBVH;
@@ -48,6 +51,10 @@ struct UnstructuredField : public SpatialField
   // must be an *index* BVH so we can access the
   // triangles based on their prim_id in the shader:
   cuda_index_bvh<basic_triangle<3,float>> m_shellBVH;
+#elif defined(WITH_HIP)
+  // must be an *index* BVH so we can access the
+  // triangles based on their prim_id in the shader:
+  hip_index_bvh<basic_triangle<3,float>> m_shellBVH;
 #else
   // must be an *index* BVH so we can access the
   // triangles based on their prim_id in the shader:

--- a/scene/volume/spatial_field/UnstructuredField.hip
+++ b/scene/volume/spatial_field/UnstructuredField.hip
@@ -1,0 +1,4 @@
+// Copyright 2023-2026 Stefan Zellmann
+// SPDX-License-Identifier: Apache-2.0
+
+#include "UnstructuredField.cpp"


### PR DESCRIPTION
Adds a HIP device so anari-visionaray runs on AMD GPUs via ROCm, mirroring the existing CUDA device. The HIP device implements the same surface and volume rendering paths as the CUDA device: triangle/sphere/etc. surfaces and the structured, block-structured, unstructured, AMR, and NanoVDB spatial fields, with a GPU LBVH for acceleration-structure builds.

To review: start with the CMake `_hip` target wiring, then the per-field `.hip` translation units and the GPU LBVH path in VisionarayScene, then the Frame and DeviceArray runtime details (frame lifetime on wait). The NanoVDB field reuses the vendored NanoVDB headers, which already gate their device qualifiers on `__HIP__` as well as `__CUDACC__`, so no changes to `external/nanovdb` were needed.

Requires a visionaray built with HIP support (the `device_vector` and BVH device paths). NanoVDB volumes are sampled through the NanoVDB accessor in device code rather than a hardware texture. On CDNA2 (gfx90a) the structured volume field falls back to nearest filtering for float textures, since that hardware lacks hardware linear-float texture filtering; RDNA3/RDNA4 support it natively.

Test Plan: built and run on real GPUs (gfx90a MI250X, gfx1100 RDNA3, gfx1201 RX 9070 XT). gfx90a example:

```sh
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
  -DANARI_VISIONARAY_ENABLE_HIP=ON -DANARI_VISIONARAY_ENABLE_CUDA=OFF \
  -DANARI_VISIONARAY_ENABLE_NANOVDB=ON \
  -DCMAKE_HIP_ARCHITECTURES=gfx90a \
  -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
  -DCMAKE_PREFIX_PATH="<visionaray>;<anari-sdk>;/opt/rocm"
cmake --build build -j --target install
HIP_VISIBLE_DEVICES=0 ./anari_validate visionaray_hip
```

A triangle surface scene, a structuredRegular volume (nearest filter on gfx90a), and a NanoVDB fog-volume sphere (nearest and linear filter) each render correctly and match the CPU device cross-check.

The CUDA build was also compile-checked with nvcc 13.3 (compile and link, not run, since no NVIDIA GPU was available); every effort was made to leave the existing CUDA path intact.

Authored with the assistance of Claude (Anthropic).